### PR TITLE
2.3.0: Snowpack version bumped to v3, style pre/post-processing leveraging snowpack plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-snowpack-plugin",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Snowpack Plugin for angular projects",
   "main": "dist/index.js",
   "repository": {
@@ -29,7 +29,7 @@
     "@angular/compiler-cli": "*",
     "@angular/core": "*",
     "rxjs": "*",
-    "snowpack": ">=2.0",
+    "snowpack": ">=3.0",
     "typescript": "*"
   },
   "files": [
@@ -41,5 +41,8 @@
       "default": "./dist/index.js"
     },
     "./vendor/hmr/hmr-accept": "./vendor/hmr/hmr-accept.js"
+  },
+  "bin": {
+    "ngsnow": "./dist/ngsnow.js"
   }
 }

--- a/src/ngsnow.ts
+++ b/src/ngsnow.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { loadConfiguration, startServer } from 'snowpack';
+import path from 'path';
+import { styleResourceManager } from './styleResource';
+
+/**
+ * The reason a wrapper code is needed for preprocess to work in dev mode is mainly because
+ * Snowpack does NOT fully build a file if the browser does not request for it,
+ * eg: the plugin can wait for `app.component.scss` at `transform()` forever but it will never be resolved unless the browser requested `app.component.scss`
+ *
+ * By using a simple wrapper for the snowpack dev server and communicating with the plugin, it is possible to trigger the above "browser request" behavior
+ */
+const devMain = async () => {
+  const config = await loadConfiguration(
+    {},
+    path.resolve(process.cwd(), 'snowpack.config.js')
+  );
+  styleResourceManager.on('request', async (stylePath) => {
+    const finalResourceUrl = server.getUrlForFile(stylePath)!;
+    server.loadUrl(finalResourceUrl);
+  });
+  const server = await startServer({ config, lockfile: null });
+};
+
+devMain();

--- a/src/styleResource.ts
+++ b/src/styleResource.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from 'events';
+import path from 'path';
+
+interface StyleResourceEvents {
+  request: (stylePath: string) => void;
+}
+
+declare interface StyleResource {
+  on<U extends keyof StyleResourceEvents>(
+    event: U,
+    listener: StyleResourceEvents[U]
+  ): this;
+  emit<U extends keyof StyleResourceEvents>(
+    event: U,
+    ...args: Parameters<StyleResourceEvents[U]>
+  ): boolean;
+}
+
+interface StyleLookup {
+  listeners: ((styleContents: string) => void)[];
+  content: string | null;
+}
+
+class StyleResource extends EventEmitter {
+  private styleLookups = new Map<string, StyleLookup>();
+  constructor() {
+    super();
+  }
+
+  /**
+   * Returns a promise of the compiled style
+   * @param stylePath Path to the style requested
+   *
+   * The compiled style will be provided from the `transform` step of the plugin.
+   */
+  async requestStyle(stylePath: string): Promise<string> {
+    stylePath = path.resolve(stylePath);
+    this.emit('request', stylePath);
+    return new Promise<string>((resolve) => {
+      const compiledStylePath = stylePath.replace(
+        path.extname(stylePath),
+        '.css'
+      );
+      if (!this.styleLookups.has(compiledStylePath)) {
+        this.styleLookups.set(compiledStylePath, {
+          listeners: [],
+          content: null,
+        });
+      }
+      const lookup = this.styleLookups.get(compiledStylePath)!;
+      if (typeof lookup.content === 'string') {
+        resolve(lookup.content);
+      } else {
+        lookup.listeners.push(resolve);
+      }
+    });
+  }
+
+  submitStyle(stylePath: string, styleContents: string) {
+    stylePath = path
+      .resolve(stylePath)
+      .replace(path.extname(stylePath), '.css');
+    if (!this.styleLookups.has(stylePath)) {
+      this.styleLookups.set(stylePath, {
+        listeners: [],
+        content: null,
+      });
+    }
+    const lookup = this.styleLookups.get(stylePath)!;
+    lookup.content = styleContents;
+    for (const listener of lookup.listeners) {
+      listener(styleContents);
+    }
+    lookup.listeners = [];
+  }
+
+  purgeCache(stylePath?: string) {
+    if (!stylePath) {
+      this.styleLookups.clear();
+    } else {
+      stylePath = path
+        .resolve(stylePath)
+        .replace(path.extname(stylePath), '.css');
+      const lookup = this.styleLookups.get(stylePath);
+      if (lookup) lookup.content = null;
+    }
+  }
+
+  get hasListener() {
+    return this.listenerCount('request') > 0;
+  }
+}
+
+// Export singleton manager
+export const styleResourceManager = new StyleResource();
+export const STYLES_FILEEXT_REGEX = /\.(css|scss|sass|styl|less)$/;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "declaration": true,
     "outDir": "dist"
   },
-  "include": ["src/index.ts"]
+  "include": ["src/index.ts", "src/ngsnow.ts"]
 }


### PR DESCRIPTION
- bump snowpack requirement to v3
- plugin must be defined AFTER a style preprocess / postprocess plugin that leverages `transform()`  in `snowpack.config.js`
- dev mode: must run new `ngsnow` bin to enable style preprocessing
- build mode: running `snowpack build` is sufficient
- `@snowpack/plugin-sass` and `@snowpack/plugin-postcss` tested to work correctly (TailwindCSS works 🚀 )